### PR TITLE
Fix mauvaise pluralisation du modèle "Information" qui est invariable

### DIFF
--- a/app/controllers/information_controller.rb
+++ b/app/controllers/information_controller.rb
@@ -1,6 +1,7 @@
-class InformationsController < ApplicationController
+class InformationController < ApplicationController
+  skip_before_action :authenticate_user!
   def new
-    @user = User.find(current_user)
+  #  @user = User.find(current_user)
     @information = Information.new
   end
 

--- a/app/helpers/information_helper.rb
+++ b/app/helpers/information_helper.rb
@@ -1,0 +1,2 @@
+module InformationHelper
+end

--- a/app/helpers/informations_helper.rb
+++ b/app/helpers/informations_helper.rb
@@ -1,2 +1,0 @@
-module InformationsHelper
-end

--- a/app/views/information/create.html.erb
+++ b/app/views/information/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Information#create</h1>
+<p>Find me in app/views/information/create.html.erb</p>

--- a/app/views/information/new.html.erb
+++ b/app/views/information/new.html.erb
@@ -3,13 +3,14 @@
 <br>
 <div class="container" style="width: 70%; font-family: Quicksand; font-weight: lighter;">
   <div class="row">
-    <%= simple_form_for [@information] do |f| %>
-    <%= f.input :type_message %>
-    <%= f.input :subject %>
-    <%= f.input :message %>
-    <br>
-    <br class="text-center">
-    <%= f.submit "Valider" %>
+
+    <%= simple_form_for(@information) do |f| %>
+      <%= f.input :type_message %>
+      <%= f.input :subjet %>
+      <%= f.input :message %>
+      <br>
+      <br class="text-center">
+      <%= f.submit "Valider" %>
     <% end %>
     <br>
   </div>

--- a/app/views/informations/create.html.erb
+++ b/app/views/informations/create.html.erb
@@ -1,3 +1,0 @@
-<h1>Informations#create</h1>
-<p>Find me in app/views/informations/create.html.erb</p>
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,8 @@ Rails.application.routes.draw do
   scope '(:locale)', locale: /fr|cat/ do
     root to: 'pages#home'
     resources :musics
-    resources :users do
-      resources :informations, only: [ :new, :create]
-    end
+    resources :information, only: [:new, :create]
+
     resources :pictures
 
     get '/wedding', to: 'pages#wedding'


### PR DESCRIPTION
```ruby
"information".pluralize
# => "information"
```

https://en.wiktionary.org/wiki/information#Noun

Rails s'attend à ce que le pluriel de cette ressource soit écrit "information" et n'identifiait donc pas correctement les `resources :informations` définies dans les routes (le lien ne se faisait pas avec le modèle `Information`). Par conséquent tout le système de routes sur ce modèle ne pouvait pas fonctionner correctement. 

De plus ces routes ne doivent pas être restées sous les `:users` pour éviter l'usurpation d'identité : c'est le current_user dans le controller qui détermine l'user auquelle se rapporte l'Information, pas le paramètre de l'url que tout le monde pourrait changer pour se faire passer par quelqu'un d'autre.